### PR TITLE
Disable pointer events on dragging.

### DIFF
--- a/src/lib/Splitpanes.svelte
+++ b/src/lib/Splitpanes.svelte
@@ -742,6 +742,7 @@
 			}
 			.splitpanes--dragging & {
 				transition: none;
+				pointer-events: none;
 			}
 		}
 		// Disable default zoom behavior on touch device when double tapping splitter.


### PR DESCRIPTION
Let's assume we change the following line in the example:
https://github.com/orefalo/svelte-splitpanes/blob/2fcc1aa99fb923c67d29e870b60a1abc4c4c9b38/src/comp/MinMax.svelte#L7-L12
to the following:
```svelte
    <Pane minSize="20" maxSize="70">
        <div style="cursor: not-allowed;">1
            <br />
            <em class="specs">I have a min height of 20% &amp; max height of 70%</em>
        </div>
    </Pane>
```

When we run the example, we'll see that while the user drag the splitter, she may still see the new cursor although she's still dragging (tested in Firefox and Edge):

https://user-images.githubusercontent.com/1467072/174052570-bae2eaaa-4c18-47b3-b7c8-75ea885f6cf2.mov

Split.js fix it in the simplest way - just [set the CSS pointer events property to `none`](https://github.com/nathancahill/split/blob/f9d7b974d24287864792347edd2c76581f117a22/packages/splitjs/src/split.js#L540-L548).
This PR does exactly this thing. Result after fix:

https://user-images.githubusercontent.com/1467072/174052584-96ef2a57-d818-44ec-a216-1ecf43b17dd1.mov
