### PR TITLE
Update isMouseDown = false on double click.

### DIFF
--- a/src/lib/Splitpanes.svelte
+++ b/src/lib/Splitpanes.svelte
@@ -269,6 +269,10 @@
 
 		dispatch('pane-maximize', splitterPane);
 		dispatchSizeEvent('resized');
+
+		// onMouseUp might not be called on the second click, so update the mouse state.
+		// TODO: Should also check and unbind events, but better IMO to not bind&unbind on every click, so ignored for now.
+		isMouseDown = false;
 	}
 
 	function prepareSizeEvent(): IPaneSizingEvent[] {


### PR DESCRIPTION
This makes the `splitpanes--dragging` class disappear after splitter double click.
This results in a correct folding/expanding transition on double click. Before this PR, if you double click on a splitter you'd see the pane gets expanded, but without animation.

It was kinda half my fault in my old PR #5, but it's half of the original code fault, because on double click `isMouseDown` is `true`, at least in Firefox, while it definitely should be `false`.
I think the reasoning is because on the second click of the double click, the browser doesn't sends the event of `mouseUp`, but rather sends the event of `dblClick`.