### PR TITLE
Fix bad code typo in the docs

### DIFF
--- a/src/comp/AddRemoveSplitter.svelte
+++ b/src/comp/AddRemoveSplitter.svelte
@@ -26,8 +26,7 @@
 			<span>{i + 1}</span>
 		</Pane>
 	{/each}
-</Splitpanes>
-<HighlightSvelte {code} />`;
+</Splitpanes>`;
 </script>
 
 <h2>Adding splitters programmatically</h2>


### PR DESCRIPTION
Fix bad code typo in the docs, showing accidentally the `<HighlightSvelte {code} />` part