### PR TITLE
:sparkles: feat: simpler and more intuitive sizing after panes adding/removing

### DIFF
--- a/src/lib/Pane.svelte
+++ b/src/lib/Pane.svelte
@@ -87,7 +87,8 @@
 			snap: () => snapSize,
 			setSplitterActive: (isActive: boolean) => {
 				isSplitterActive = isActive;
-			}
+			},
+			isReady: false
 		};
 		onPaneAdd(inst);
 	});

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -46,4 +46,5 @@ export interface IPane {
 	setSz: (number: number) => void;
 	setSplitterActive: (isActive: boolean) => void;
 	givenSize: number | null;
+	isReady: boolean;
 }


### PR DESCRIPTION
This is just more intuitive, friendly and "fair".
This make sure that the "auto-sized" panes keeps their proportional size after adding/removing.

In addition, it makes the code simpler.

See `/examples/add-remove-splitter` example for the difference in the behavior.