### PR TITLE
fix: pane object not being returned

### DIFF
--- a/src/lib/Splitpanes.svelte
+++ b/src/lib/Splitpanes.svelte
@@ -226,9 +226,7 @@
 	function onPaneClick(_event: MouseEvent, key: any) {
 		dispatch(
 			'pane-click',
-			panes.find((pane) => {
-				pane.key == key;
-			})
+			panes.find((pane) => pane.key === key)
 		);
 	}
 


### PR DESCRIPTION
According to the [docs](https://github.com/orefalo/svelte-splitpanes#events), the clicked pane object should be returned but it was not working.

To replicate:
1. Visit: `https://orefalo.github.io/svelte-splitpanes/examples/listen-to-events`.
2. Click on any panes.
3. Notice that the `event.detail` is missing and only the `event.type` is being logged.

The bug seems quite obvious in the implementation. I took the liberty to change from `==` to `===` but feel free to revert that part.