### PR TITLE
chore: add a 'gathering' round for the panes during SSR, fixing some tech limits issues

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -7,6 +7,7 @@ export type PaneInitFunction = (key: any) => {
 	onSplitterDown: (_event: TouchEvent | MouseEvent) => void;
 	onSplitterClick: (event: MouseEvent) => void;
 	onSplitterDblClick: (_event: MouseEvent) => void;
+	undefinedPaneInitSize: number;
 };
 
 // methods passed from splitpane to children panes
@@ -15,6 +16,7 @@ export interface SplitContext {
 	veryFirstPaneKey: Readable<any>;
 	isHorizontal: Readable<boolean>;
 	showFirstSplitter: Readable<boolean>;
+	ssrRegisterPaneSize: (size: number | null) => void;
 	onPaneInit: PaneInitFunction;
 	onPaneAdd: (pane: IPane) => Promise<void>;
 	onPaneRemove: (key: any) => Promise<void>;

--- a/src/lib/internal/GatheringRound.svelte
+++ b/src/lib/internal/GatheringRound.svelte
@@ -1,0 +1,11 @@
+<script lang="ts" context="module">
+	export const gatheringKey = {};
+</script>
+
+<script lang="ts">
+	import { setContext } from 'svelte';
+
+	setContext(gatheringKey, true);
+</script>
+
+<slot />

--- a/src/lib/internal/env.ts
+++ b/src/lib/internal/env.ts
@@ -1,0 +1,8 @@
+/**
+ * Tells if we're running on a browser client or on SSR.
+ *
+ * If `import.meta.env` and `import.meta.env.SSR` are defined (which are defined automatically in Vite),
+ *  this constant would be resolved in build time during minification (assuming the user has enabled minification).
+ */
+export const browser: boolean =
+	import.meta.env != null && import.meta.env.SSR != null ? !import.meta.env.SSR : typeof window !== 'undefined';


### PR DESCRIPTION
The problem that happen before:

On SSR, `Splitpanes` render each pane seperatly, and not let the whole panes to communicate.

The main first problem starts when the user didn't specify a size for some pane(s). How this library know which size the pane should have if it was undefined? Answer: `(100 - ssrPaneDefinedSizeSum) / ssrPaneUndefinedSizeCount`. The issue is that Svelte SSR just chains the resulted strings together, and every pane can't predict the total defined size (and the count) of the next panes. As a result, before this commit, in the SSR output, Splitpanes just left the CSS size to be blank, hoping that the browser will do the correct computation, but sadly it's not... As a workaround to this specific problem,
we tried to add `min-size` and `max-size` to the CSS output to force the correct sizing, but it fails to be exact due to the splitter size.

There are also much other issues, most of them have a workaround, but hardest is a correct pixel support for regular/min/max sizes as well, that will render correctly in SSR.

Solving this issue will make all this problems trivial, and this is what this change is doing!

The solution:
Render the inner slot content of `<Splitpanes>` twice: One will be a "dry" run that just counts the panes amount and its sizes, and the second really renders them (as happens now).

In the second round, the "real" rendering will take place, but now every pane knows the sizes of its sibilings.

Remark: A small side effect is that during SSR,
the props of the `Pane` components are calculated twice (at each round). However, the user content&components inside each `<Pane>` are only rendered once - in the second "real" rendering round, so the possible issues are very small and rare.