### PR TITLE
refactor: use 'esm-env-robust' since the server code is dramatically being reduced

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,5 +82,8 @@
 		"cz-customizable": {
 			"config": ".cz-config.cjs"
 		}
+	},
+	"dependencies": {
+		"esm-env-robust": "^0.0.3"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,7 @@ specifiers:
   eslint-config-prettier: 8.5.0
   eslint-plugin-markdown: 3.0.0
   eslint-plugin-svelte3: 4.0.0
+  esm-env-robust: ^0.0.3
   highlight.js: 11.7.0
   husky: 8.0.2
   lint-staged: 13.1.0
@@ -32,6 +33,9 @@ specifiers:
   tslib: 2.4.1
   typescript: 4.9.4
   vite: 4.0.3
+
+dependencies:
+  esm-env-robust: 0.0.3
 
 optionalDependencies:
   '@playwright/test': 1.29.1
@@ -1887,10 +1891,16 @@ packages:
       - supports-color
     dev: true
 
+  /esm-env-robust/0.0.3:
+    resolution:
+      { integrity: sha512-90Gnuw2DALOqlL1581VxP3GHPUNHX9U+fQ+8FNcTTFClhY5gEggAAnJ3q1b2Oq23knRsjv8YpNeMRPaMLUymOA== }
+    dependencies:
+      esm-env: 1.0.0
+    dev: false
+
   /esm-env/1.0.0:
     resolution:
       { integrity: sha512-Cf6VksWPsTuW01vU9Mk/3vRue91Zevka5SjyNf3nEpokFRuqt/KjUQoGAwq9qMmhpLTHmXzSIrFRw8zxWzmFBA== }
-    dev: true
 
   /espree/9.4.1:
     resolution:

--- a/src/lib/internal/env.ts
+++ b/src/lib/internal/env.ts
@@ -1,8 +1,1 @@
-/**
- * Tells if we're running on a browser client or on SSR.
- *
- * If `import.meta.env` and `import.meta.env.SSR` are defined (which are defined automatically in Vite),
- *  this constant would be resolved in build time during minification (assuming the user has enabled minification).
- */
-export const browser: boolean =
-	import.meta.env != null && import.meta.env.SSR != null ? !import.meta.env.SSR : typeof window !== 'undefined';
+export { BROWSER as browser } from 'esm-env-robust';


### PR DESCRIPTION
I've being playing around last week for a good solution for the following problem: How to compute the library minified footprint?
So as you can see by the new fancy bag in the README and the last commits, I've added some Vite plugin and modify Rollup behavior a little bit on the docs build.
As for now, the badge and the size computation console output, shows the real minified library code consumption.

The problem is that the env constant `browser` is not being minified, disallowing a huge dead code elimination. 
It seems that all common JS minifiers (tested on ESBuild and Terser) had failed to minimize the simple expression: `import.meta.env != null && import.meta.env.SSR != null`, where the values are being a constant simple JS values.

The analyzed minimized size before in bytes:
client: 16557, server: 15015

After this PR:
client: 15210, server: 5878

Note: You can see these numbers on the build output, which is available also as the output of Github Actions.

As you can see, the big reduce is on the server, because there is a huge client side logics of the panes "add", "remove", "dragged", and many others, that doesn't need to be evaluated on SSR.

I believe server side size is important to be reduced.
For example, the cloudflare fancy zero-loading time Edge servers, need that the user server final code will be no more than 1MB, and Svelte Splitpanes consumes 1.5% of the total cap before this PR, and 0.5% of the total cap after this PR.

Hence I think it's worth to use `esm-env-robust` as a dependency. The library user won't need to do anything on his behalf, but he'll get the advantage on the reduced sizes.