### PR TITLE
chore: move to esm-env instead of esm-env-robust

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
 		}
 	},
 	"dependencies": {
-		"esm-env-robust": "^0.0.3"
+		"esm-env": "^1.0.0"
 	},
 	"exports": {
 		"./package.json": "./package.json",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ specifiers:
   eslint-config-prettier: 8.6.0
   eslint-plugin-markdown: 3.0.0
   eslint-plugin-svelte3: 4.0.0
-  esm-env-robust: ^0.0.3
+  esm-env: ^1.0.0
   highlight.js: 11.7.0
   husky: 8.0.3
   lint-staged: 13.1.2
@@ -35,7 +35,7 @@ specifiers:
   vite: 4.1.4
 
 dependencies:
-  esm-env-robust: 0.0.3
+  esm-env: 1.0.0
 
 optionalDependencies:
   '@playwright/test': 1.31.1
@@ -1901,13 +1901,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
-
-  /esm-env-robust/0.0.3:
-    resolution:
-      { integrity: sha512-90Gnuw2DALOqlL1581VxP3GHPUNHX9U+fQ+8FNcTTFClhY5gEggAAnJ3q1b2Oq23knRsjv8YpNeMRPaMLUymOA== }
-    dependencies:
-      esm-env: 1.0.0
-    dev: false
 
   /esm-env/1.0.0:
     resolution:

--- a/src/lib/internal/env.ts
+++ b/src/lib/internal/env.ts
@@ -1,1 +1,1 @@
-export { BROWSER as browser } from 'esm-env-robust';
+export { BROWSER as browser } from 'esm-env';

--- a/vite.config.js
+++ b/vite.config.js
@@ -25,13 +25,6 @@ const config = {
 				manualChunks: manualChunksForAnalyzing
 			}
 		}
-	},
-	ssr: {
-		noExternal: [
-			// So that 'esm-env-robust' dependency will be embedded,
-			//  and (a huge!!) minification could be performed by knowing if we're running on the server or on the client.
-			'esm-env-robust'
-		]
 	}
 };
 


### PR DESCRIPTION
PR sveltejs/sites#445 is merged, fixing benmccann/esm-env#1, but still not deployed.

After the change will finally be deployed to the official svelte.dev site, we can merge this changes safely.

A simple reproduction to check if svelte.dev has the fix deployed, is to see if this example builds up correctly:
https://svelte.dev/repl/58ae14b7f112454aa83125b767f9a62a?version=3.54.0

@orefalo don't merge until they deploy it