### PR TITLE
fix: Update Splitpanes.svelte to check for `container`

### DIFF
--- a/src/lib/Splitpanes.svelte
+++ b/src/lib/Splitpanes.svelte
@@ -928,6 +928,9 @@
 		and if not update the internal order.
 	 */
 	function verifyAndUpdatePanesOrder() {
+		if (!container) {
+			return
+		}
 		const { children } = container;
 		let currentPaneIndex = 0;
 		let needReorder = false;

--- a/src/lib/Splitpanes.svelte
+++ b/src/lib/Splitpanes.svelte
@@ -929,7 +929,7 @@
 	 */
 	function verifyAndUpdatePanesOrder() {
 		if (!container) {
-			return
+			return;
 		}
 		const { children } = container;
 		let currentPaneIndex = 0;


### PR DESCRIPTION
Check for null `container` before accessing children.

We are using `svelte-splitpanes` in our app, and loading another Svelte component programmatically causes `afterUpdate` to get called in our `Splitpanes` component (which causes `verifyAndUpdatePanesOrder` to get called) before it has mounted. This checks for the presence of `container` before treating it as non-null.