### PR TITLE
chore: ignore pnpm-lock recursively during linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
 		"check:watch": "svelte-check --tsconfig ./tsconfig.json --watch",
 		"lint": "npm run lint-format && npm run lint-es",
 		"lint-es": "eslint --cache --ignore-path .gitignore **/*.{js,ts,svelte,json,md}",
-		"lint-format": "prettier --ignore-path .gitignore --check --cache --plugin-search-dir=. !./pnpm-lock.yaml !./CHANGELOG.md .",
-		"format": "prettier --ignore-path .gitignore --write --cache --plugin-search-dir=. !./pnpm-lock.yaml !./CHANGELOG.md .",
+		"lint-format": "prettier --ignore-path .gitignore --check --cache --plugin-search-dir=. !**/pnpm-lock.yaml !./CHANGELOG.md .",
+		"format": "prettier --ignore-path .gitignore --write --cache --plugin-search-dir=. !**/pnpm-lock.yaml !./CHANGELOG.md .",
 		"commit": "npx lint-staged && cross-env NO_VERIFY=1 node ./node_modules/cz-customizable/standalone.js",
 		"fetch-and-publish": "node scripts/fetch-and-publish.js"
 	},

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 		"check": "svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-check --tsconfig ./tsconfig.json --watch",
 		"lint": "npm run lint-format && npm run lint-es",
-		"lint-es": "eslint --cache --ignore-path .gitignore **/*.{js,ts,svelte,json,md}",
+		"lint-es": "eslint --cache --ignore-path .gitignore .",
 		"lint-format": "prettier --ignore-path .gitignore --check --cache --plugin-search-dir=. !**/pnpm-lock.yaml !./CHANGELOG.md .",
 		"format": "prettier --ignore-path .gitignore --write --cache --plugin-search-dir=. !**/pnpm-lock.yaml !./CHANGELOG.md .",
 		"commit": "npx lint-staged && cross-env NO_VERIFY=1 node ./node_modules/cz-customizable/standalone.js",


### PR DESCRIPTION
When running the lint script locally, the pnpm-lock file in `examples/` was complaining. This change ignores this path when linting. 

Also removing the explicit list of files that are being linted, since they include node_modules, which makes eslint complain. Using `.` lints everything thats not ignored