### PR TITLE
Fix self-closing `<div>` tag

### DIFF
--- a/src/lib/Pane.svelte
+++ b/src/lib/Pane.svelte
@@ -117,7 +117,8 @@
       on:mousedown={carefullClientCallbacks?.('onSplitterDown')}
       on:touchstart={carefullClientCallbacks?.('onSplitterDown')}
       on:click={carefullClientCallbacks?.('onSplitterClick')}
-      on:dblclick={carefullClientCallbacks?.('onSplitterDblClick')} />
+      on:dblclick={carefullClientCallbacks?.('onSplitterDblClick')}>
+	</div>
   {/if}
 
   <!-- Pane -->


### PR DESCRIPTION
Replaces a self-closing `<div />` with a proper `<div></div>` to avoid Svelte compiler warnings.
As described in #114, I get the following warning during my build process:


▲ [WARNING] Self-closing HTML tags for non-void elements are ambiguous — use `<div ...></div>` rather than `<div ... />`
https://svelte.dev/e/element_invalid_self_closing_tag [plugin esbuild-svelte]

    node_modules/svelte-splitpanes/dist/Pane.svelte:88:4:
      88 │     <div
         ╵     ~~~~
                   ~~~~~~~~~~~~~~~
