### PR TITLE
fix: replace `$app/environment` with standard browser detection

### DIFF
--- a/src/lib/internal/env.ts
+++ b/src/lib/internal/env.ts
@@ -1,9 +1,7 @@
 /**
  * Browser detection utility.
  *
- * Uses SvelteKit's native browser detection which is more reliable
- * and doesn't require external dependencies.
- *
- * @see https://kit.svelte.dev/docs/modules#$app-environment
+ * Uses a standard check rather than SvelteKit's $app/environment
+ * so the package works in non-SvelteKit environments.
  */
-export { browser } from '$app/environment';
+export const browser = typeof window !== 'undefined';


### PR DESCRIPTION
Using `$app/environment` causes a build error when svelte-splitpanes is used outside of SvelteKit (plain Svelte apps).    
Replace with `typeof window !== 'undefined'`, which is equivalent and has no SvelteKit dependency.

Esbuild error in my plain Svelte app:
```
✘ [ERROR] Could not resolve "$app/environment"
   node_modules/svelte-splitpanes/dist/internal/env.js:9:24:
     9 │ export { browser } from '$app/environment';
```